### PR TITLE
Refactor "required" fields.

### DIFF
--- a/_sources/prov-activity/schema.json
+++ b/_sources/prov-activity/schema.json
@@ -38,6 +38,12 @@
         "id": {
           "$ref": "bblocks://ogc.ogc-utils.prov#objectref"
         },
+        "provType": {
+          "$ref": "#/$defs/ActivityTypes"
+        },
+        "prov:type": {
+          "$ref": "#/$defs/ActivityTypes"
+        },
         "activityType": {
           "$ref": "bblocks://ogc.ogc-utils.prov#oneOrMoreObjectref"
         },
@@ -158,63 +164,6 @@
           ]
         }
       },
-      "anyOf": [
-        {
-          "properties": {
-            "provType": {
-              "$ref": "#/$defs/ActivityTypes"
-            }
-          },
-          "required": [
-            "provType"
-          ]
-        },
-        {
-          "properties": {
-            "prov:type": {
-              "$ref": "#/$defs/ActivityTypes"
-            }
-          },
-          "required": [
-            "prov:type"
-          ]
-        },
-        {
-          "properties": {
-            "type": {
-              "$ref": "#/$defs/ActivityTypes"
-            }
-          },
-          "required": [
-            "type"
-          ]
-        },
-        {
-          "required": [
-            "used"
-          ]
-        },
-        {
-          "required": [
-            "wasInformedBy"
-          ]
-        },
-        {
-          "required": [
-            "endedAtTime"
-          ]
-        },
-        {
-          "required": [
-            "startedAtTime"
-          ]
-        },
-        {
-          "required": [
-            "wasAssociatedWith"
-          ]
-        }
-      ],
       "allOf": [
         {
           "$ref": "bblocks://ogc.ogc-utils.prov#influenced"
@@ -322,7 +271,7 @@
       ]
     },
     "Invalidation": {
-            "$anchor": "Invalidation",
+      "$anchor": "Invalidation",
       "allOf": [
         {
           "$ref": "#/$defs/ActivityInfluence"
@@ -356,7 +305,7 @@
       ]
     },
     "Communication": {
-                "$anchor": "Communication",
+      "$anchor": "Communication",
       "allOf": [
         {
           "$ref": "#/$defs/ActivityInfluence"
@@ -508,7 +457,7 @@
       }
     },
     "Attribution": {
-                    "$anchor": "Attribution",
+      "$anchor": "Attribution",
       "type": "object",
       "properties": {
         "id": {

--- a/_sources/prov-agent/schema.json
+++ b/_sources/prov-agent/schema.json
@@ -46,6 +46,12 @@
         "agentType": {
           "$ref": "bblocks://ogc.ogc-utils.prov#oneOrMoreObjectref"
         },
+        "provType": {
+          "$ref": "#/$defs/AgentType"
+        },
+        "prov:type": {
+          "$ref": "#/$defs/AgentType"
+        },
         "name": {
           "type": "string"
         },
@@ -91,53 +97,6 @@
         {
           "required": [
             "id"
-          ]
-        }
-      ],
-      "anyOf": [
-        {
-          "properties": {
-            "provType": {
-              "$ref": "#/$defs/AgentType"
-            }
-          },
-          "required": [
-            "provType"
-          ]
-        },
-        {
-          "properties": {
-            "type": {
-              "$ref": "#/$defs/AgentType"
-            }
-          },
-          "required": [
-            "type"
-          ]
-        },
-        {
-          "properties": {
-            "agentType": {
-              "$ref": "#/$defs/AgentType"
-            }
-          },
-          "required": [
-            "agentType"
-          ]
-        },
-        {
-          "properties": {
-            "prov:type": {
-              "$ref": "#/$defs/AgentType"
-            }
-          },
-          "required": [
-            "prov:type"
-          ]
-        },
-        {
-          "required": [
-            "actedOnBehalfOf"
           ]
         }
       ],

--- a/_sources/prov-bundled/schema.json
+++ b/_sources/prov-bundled/schema.json
@@ -433,9 +433,6 @@
         "id": {
           "$ref": "#/$defs/objectref"
         },
-        "type": {
-          "$ref": "#/$defs/ActivityTypes"
-        },
         "activityType": {
           "$ref": "#/$defs/oneOrMoreObjectref"
         },

--- a/_sources/prov-entity/schema.json
+++ b/_sources/prov-entity/schema.json
@@ -32,6 +32,12 @@
         "id": {
           "$ref": "bblocks://ogc.ogc-utils.prov#objectref"
         },
+        "provType": {
+          "$ref": "#/$defs/EntityTypes"
+        },
+        "prov:type": {
+          "$ref": "#/$defs/EntityTypes"
+        },
         "featureType": {
           "$ref": "bblocks://ogc.ogc-utils.prov#oneOrMoreObjectref"
         },
@@ -176,66 +182,6 @@
       "anyOf": [
         {
           "properties": {
-            "provType": {
-              "$ref": "#/$defs/EntityTypes"
-            }
-          },
-          "required": [
-            "provType"
-          ]
-        },
-        {
-          "properties": {
-            "prov:type": {
-              "$ref": "#/$defs/EntityTypes"
-            }
-          },
-          "required": [
-            "prov:type"
-          ]
-        },
-        {
-          "properties": {
-            "type": {
-              "$ref": "#/$defs/EntityTypes"
-            }
-          },
-          "required": [
-            "type"
-          ]
-        },
-        {
-          "required": [
-            "featureType"
-          ]
-        },
-        {
-          "required": [
-            "entityType"
-          ]
-        },
-        {
-          "required": [
-            "wasGeneratedBy"
-          ]
-        },
-        {
-          "required": [
-            "wasAttributedTo"
-          ]
-        },
-        {
-          "required": [
-            "wasDerivedFrom"
-          ]
-        },
-        {
-          "required": [
-            "has_provenance"
-          ]
-        },
-        {
-          "properties": {
             "type": {
               "type": "string",
               "const": "Collection"
@@ -267,6 +213,13 @@
             "hadMember",
             "type"
           ]
+        },
+        {
+          "not": {
+            "required": [
+              "hadMember", "type"
+            ]
+          }
         }
       ],
       "allOf": [

--- a/_sources/prov/schema.json
+++ b/_sources/prov/schema.json
@@ -93,13 +93,156 @@
       "$anchor": "Entity",
       "$ref": "bblocks://ogc.ogc-utils.prov-entity"
     },
+    "EntityWithRequirements": {
+      "allOf": [
+        {
+          "$ref": "#Entity"
+        },
+        {
+          "anyOf": [
+            {
+              "required": [
+                "provType"
+              ]
+            },
+            {
+              "required": [
+                "prov:type"
+              ]
+            },
+            {
+              "required": [
+                "type"
+              ]
+            },
+            {
+              "required": [
+                "featureType"
+              ]
+            },
+            {
+              "required": [
+                "entityType"
+              ]
+            },
+            {
+              "required": [
+                "wasGeneratedBy"
+              ]
+            },
+            {
+              "required": [
+                "wasAttributedTo"
+              ]
+            },
+            {
+              "required": [
+                "wasDerivedFrom"
+              ]
+            },
+            {
+              "required": [
+                "has_provenance"
+              ]
+            }
+          ]
+        }
+      ]
+    },
     "Activity": {
       "$anchor": "Activity",
       "$ref": "bblocks://ogc.ogc-utils.prov-activity"
     },
+    "ActivityWithRequirements": {
+      "allOf": [
+        {
+          "$ref": "#Activity"
+        },
+        {
+          "anyOf": [
+            {
+              "required": [
+                "provType"
+              ]
+            },
+            {
+              "required": [
+                "prov:type"
+              ]
+            },
+            {
+              "required": [
+                "type"
+              ]
+            },
+            {
+              "required": [
+                "used"
+              ]
+            },
+            {
+              "required": [
+                "wasInformedBy"
+              ]
+            },
+            {
+              "required": [
+                "endedAtTime"
+              ]
+            },
+            {
+              "required": [
+                "startedAtTime"
+              ]
+            },
+            {
+              "required": [
+                "wasAssociatedWith"
+              ]
+            }
+          ]
+        }
+      ]
+    },
     "Agent": {
       "$anchor": "Agent",
       "$ref": "bblocks://ogc.ogc-utils.prov-agent"
+    },
+    "AgentWithRequirements": {
+      "allOf": [
+        {
+          "$ref": "#Agent"
+        },
+        {
+          "anyOf": [
+            {
+              "required": [
+                "provType"
+              ]
+            },
+            {
+              "required": [
+                "type"
+              ]
+            },
+            {
+              "required": [
+                "agentType"
+              ]
+            },
+            {
+              "required": [
+                "prov:type"
+              ]
+            },
+            {
+              "required": [
+                "actedOnBehalfOf"
+              ]
+            }
+          ]
+        }
+      ]
     },
     "Association": {
       "$anchor": "Association",
@@ -207,13 +350,13 @@
       "items": {
         "oneOf": [
           {
-            "$ref": "#Entity"
+            "$ref": "#/$defs/EntityWithRequirements"
           },
           {
-            "$ref": "#Agent"
+            "$ref": "#/$defs/AgentWithRequirements"
           },
           {
-            "$ref": "#Activity"
+            "$ref": "#/$defs/ActivityWithRequirements"
           }
         ]
       }
@@ -224,10 +367,10 @@
       "$ref": "#Prov"
     },
     {
-      "$ref": "#Entity"
+      "$ref": "#/$defs/EntityWithRequirements"
     },
     {
-      "$ref": "#Activity"
+      "$ref": "#/$defs/ActivityWithRequirements"
     }
   ]
 }


### PR DESCRIPTION
Requirements are only applied at the top level of the prov object, but individual instances don't have any required fields. This relaxes the schema and makes it compatible with external resources such as EarthCode.